### PR TITLE
Add 1 to excursion if cesi_code

### DIFF
--- a/R/calc-wqi.R
+++ b/R/calc-wqi.R
@@ -81,6 +81,10 @@ bootstrap_wqis_column <- function (x, R) {
 }
 
 boot_wqis <- function (x, ci, cesi_code) {
+
+  if (cesi_code) {
+    x <- dplyr::mutate_(x, Excursion = ~Excursion + 1)
+  }
   x <- dplyr::select_(x, ~Variable, ~Excursion, ~Date)
   x <- tidyr::spread_(x, "Variable", "Excursion")
   x <- dplyr::select_(x, ~-Date)


### PR DESCRIPTION
Add 1 to the excursion value if calculating CIs with cesi code, as it wants straight ratios (while `wqbc::get_excursions` subtracts 1 so that no excursion == 0).
