### PR TITLE
Re-document with roxygen2 version 7.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,6 @@ Remotes:
     bcgov/rems,
     bcgov/canwqdata
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/man/calc_limits.Rd
+++ b/man/calc_limits.Rd
@@ -4,10 +4,18 @@
 \alias{calc_limits}
 \title{Calculate Limits}
 \usage{
-calc_limits(x, by = NULL, term = "long", dates = NULL,
-  keep_limits = TRUE, delete_outliers = FALSE,
-  estimate_variables = FALSE, clean = TRUE, limits = wqbc::limits,
-  messages = getOption("wqbc.messages", default = TRUE))
+calc_limits(
+  x,
+  by = NULL,
+  term = "long",
+  dates = NULL,
+  keep_limits = TRUE,
+  delete_outliers = FALSE,
+  estimate_variables = FALSE,
+  clean = TRUE,
+  limits = wqbc::limits,
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{x}{A data.frame of water quality readings to calculate the limits for.}

--- a/man/clean_wqdata.Rd
+++ b/man/clean_wqdata.Rd
@@ -4,10 +4,17 @@
 \alias{clean_wqdata}
 \title{Clean Water Quality Data}
 \usage{
-clean_wqdata(x, by = NULL, max_cv = Inf, sds = 10,
-  ignore_undetected = TRUE, large_only = TRUE,
-  delete_outliers = FALSE, remove_blanks = FALSE,
-  messages = getOption("wqbc.messages", default = TRUE))
+clean_wqdata(
+  x,
+  by = NULL,
+  max_cv = Inf,
+  sds = 10,
+  ignore_undetected = TRUE,
+  large_only = TRUE,
+  delete_outliers = FALSE,
+  remove_blanks = FALSE,
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{x}{The data.frame to clean.}

--- a/man/lookup_codes.Rd
+++ b/man/lookup_codes.Rd
@@ -4,8 +4,10 @@
 \alias{lookup_codes}
 \title{Lookup Codes}
 \usage{
-lookup_codes(variables = NULL, messages = getOption("wqbc.messages",
-  default = TRUE))
+lookup_codes(
+  variables = NULL,
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{variables}{An optional character vector of variables to lookup codes.}

--- a/man/lookup_limits.Rd
+++ b/man/lookup_limits.Rd
@@ -4,8 +4,13 @@
 \alias{lookup_limits}
 \title{Lookup Limits}
 \usage{
-lookup_limits(ph = NULL, hardness = NULL, chloride = NULL,
-  methyl_mercury = NULL, term = "long")
+lookup_limits(
+  ph = NULL,
+  hardness = NULL,
+  chloride = NULL,
+  methyl_mercury = NULL,
+  term = "long"
+)
 }
 \arguments{
 \item{ph}{A number indicating the pH in pH units at the site of interest.}

--- a/man/lookup_variables.Rd
+++ b/man/lookup_variables.Rd
@@ -4,8 +4,10 @@
 \alias{lookup_variables}
 \title{Lookup Variables}
 \usage{
-lookup_variables(codes = NULL, messages = getOption("wqbc.messages",
-  default = TRUE))
+lookup_variables(
+  codes = NULL,
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{codes}{An optional character vector of codes to look up variables.}

--- a/man/plot_timeseries.Rd
+++ b/man/plot_timeseries.Rd
@@ -4,8 +4,13 @@
 \alias{plot_timeseries}
 \title{Plot Time Series Data}
 \usage{
-plot_timeseries(data, by = NULL, y0 = TRUE, size = 1,
-  messages = getOption("wqbc.messages", default = TRUE))
+plot_timeseries(
+  data,
+  by = NULL,
+  y0 = TRUE,
+  size = 1,
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{data}{A data frame of the data to plot.}

--- a/man/set_non_detects.Rd
+++ b/man/set_non_detects.Rd
@@ -4,8 +4,12 @@
 \alias{set_non_detects}
 \title{Set value for 'non-detects'}
 \usage{
-set_non_detects(value, mdl_flag = NULL, mdl_value = NULL,
-  mdl_action = c("zero", "mdl", "half", "na"))
+set_non_detects(
+  value,
+  mdl_flag = NULL,
+  mdl_value = NULL,
+  mdl_action = c("zero", "mdl", "half", "na")
+)
 }
 \arguments{
 \item{value}{a numeric vector of measured values}

--- a/man/standardize_wqdata.Rd
+++ b/man/standardize_wqdata.Rd
@@ -5,8 +5,11 @@
 \alias{standardise_wqdata}
 \title{Standardize Water Quality Data}
 \usage{
-standardize_wqdata(x, strict = TRUE,
-  messages = getOption("wqbc.messages", default = TRUE))
+standardize_wqdata(
+  x,
+  strict = TRUE,
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{x}{A data.frame to standardize.}

--- a/man/substitute_units.Rd
+++ b/man/substitute_units.Rd
@@ -4,8 +4,7 @@
 \alias{substitute_units}
 \title{Substitute Units}
 \usage{
-substitute_units(x, messages = getOption("wqbc.messages", default =
-  TRUE))
+substitute_units(x, messages = getOption("wqbc.messages", default = TRUE))
 }
 \arguments{
 \item{x}{The character vector of units to substitute.}

--- a/man/substitute_variables.Rd
+++ b/man/substitute_variables.Rd
@@ -4,8 +4,11 @@
 \alias{substitute_variables}
 \title{Substitute Variables}
 \usage{
-substitute_variables(x, strict = TRUE,
-  messages = getOption("wqbc.messages", default = TRUE))
+substitute_variables(
+  x,
+  strict = TRUE,
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{x}{A character vector of variable names to substitute.}

--- a/man/summarise_for_trends.Rd
+++ b/man/summarise_for_trends.Rd
@@ -4,8 +4,12 @@
 \alias{summarise_for_trends}
 \title{Summarise data by year and month}
 \usage{
-summarise_for_trends(data, breaks = NULL, FUN = "median",
-  messages = getOption("wqbc.messages", default = TRUE))
+summarise_for_trends(
+  data,
+  breaks = NULL,
+  FUN = "median",
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{data}{The data.frame to analyse.}

--- a/man/test_trends.Rd
+++ b/man/test_trends.Rd
@@ -4,8 +4,12 @@
 \alias{test_trends}
 \title{Thiel-Sen Trend Test}
 \usage{
-test_trends(data, breaks = NULL, FUN = "median",
-  messages = getOption("wqbc.messages", default = TRUE))
+test_trends(
+  data,
+  breaks = NULL,
+  FUN = "median",
+  messages = getOption("wqbc.messages", default = TRUE)
+)
 }
 \arguments{
 \item{data}{The data.frame to analyse.}
@@ -19,7 +23,7 @@ year is used.}
 }
 \value{
 A tibble data.frame with rows for each Station, Variable, and month grouping, and
-additional columns for the sen slope estinate, 95\% confidence intervals on the slope, intercept and significance at the 5\% level for the sen slope.
+additional columns for the sen slope estinate, 95\\% confidence intervals on the slope, intercept and significance at the 5\\% level for the sen slope.
 }
 \description{
 Analyses time series using the Thiel-Sen estimate of slope. It requires at least 6 years of data.

--- a/man/tidy_ec_data.Rd
+++ b/man/tidy_ec_data.Rd
@@ -4,8 +4,11 @@
 \alias{tidy_ec_data}
 \title{Tidy Environment Canada Data}
 \usage{
-tidy_ec_data(x, cols = character(0), mdl_action = c("zero", "mdl",
-  "half", "na", "none"))
+tidy_ec_data(
+  x,
+  cols = character(0),
+  mdl_action = c("zero", "mdl", "half", "na", "none")
+)
 }
 \arguments{
 \item{x}{The data to tidy.}

--- a/man/tidy_ems_data.Rd
+++ b/man/tidy_ems_data.Rd
@@ -4,8 +4,11 @@
 \alias{tidy_ems_data}
 \title{Tidy EMS Data}
 \usage{
-tidy_ems_data(x, cols = character(0), mdl_action = c("zero", "mdl",
-  "half", "na", "none"))
+tidy_ems_data(
+  x,
+  cols = character(0),
+  mdl_action = c("zero", "mdl", "half", "na", "none")
+)
 }
 \arguments{
 \item{x}{The data to tidy.}


### PR DESCRIPTION
I'm working on the Water Quality Guideline Shiny app (note this is not shinyrems, but another one called shinywqg, which just gets the limits).

The new limits table will have multiple unique values of 'Use', so need to add this to the internal and exported data and add a `use` argument to `calc_limits` and `lookup_limits`.

Before making these changes, need to re-document with roxygen2 version 7.0.1. This first pull request is just re-documentation and will send another pull request with changes to functions/data.