### PR TITLE
Summarize bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,14 +3,18 @@ Type: Package
 Title: Tidy Water Quality Data and Calculate Thresholds for British Columbia
 Version: 0.3.1.9003
 Authors@R: c(
-    person("Joe", "Thorley", , "joe@poissonconsulting.ca", c("aut", "ctr"), comment = c(ORCID = "0000-0002-7683-4592")),
-	  person("Colin", "Millar", , "colinpmillar@gmail.com", c("aut", "ctr")),
-	  person("Andy", "Teucher", , "andy.teucher@gov.bc.ca", c("aut", "cre")),
-    person("Sebastian", "Dalgarno", , "seb@poissonconsulting.ca", "ctb", comment = c(ORCID = "0000-0002-3658-4517")),
-	  person("Wendy", "Wang", role = c("ctb", "ctr")),
-	  person("Stephanie", "Hazlitt", , "stephanie.hazlitt@gov.bc.ca", "ctb"),
-	  person("Robyn", "Irvine", role = c("ctb", "ctr")),
-	  person("Province of British Columbia", role = "cph")
+    person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "ctr"),
+           comment = c(ORCID = "0000-0002-7683-4592")),
+    person("Colin", "Millar", , "colinpmillar@gmail.com", role = c("aut", "ctr")),
+    person("Andy", "Teucher", , "andy.teucher@gov.bc.ca", role = c("aut", "cre")),
+    person("Sebastian", "Dalgarno", , "seb@poissonconsulting.ca", role = "ctb",
+           comment = c(ORCID = "0000-0002-3658-4517")),
+    person("Wendy", "Wang", role = c("ctb", "ctr")),
+    person("Stephanie", "Hazlitt", , "stephanie.hazlitt@gov.bc.ca", role = "ctb"),
+    person("Robyn", "Irvine", role = c("ctb", "ctr")),
+    person("Province of British Columbia", role = "cph"),
+    person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", role = "ctb",
+           comment = c(ORCID = "0000-0001-7388-1222"))
   )
 Description: Tidies water quality data and calculates water quality thresholds 
     for British Columbia.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Remotes:
     bcgov/rems,
     bcgov/canwqdata
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 RdMacros: lifecycle

--- a/R/calc-limits.R
+++ b/R/calc-limits.R
@@ -132,7 +132,7 @@ abs_days_diff <- function(x, y) {
 
 assign_30day_periods <- function(x, dates) {
   if (!is.null(dates)) dates <- sort(unique(dates))
-  y <- unique(dplyr::select(x, .data$Date))
+  y <- unique(dplyr::select(x, "Date"))
   y <- dplyr::arrange(y, .data$Date)
   y$Period <- NA
 
@@ -224,9 +224,9 @@ calc_limits_by <- function(x, term, dates, limits, messages) {
   }
 
   if (!is.null(x$DetectionLimit)) {
-    x <- dplyr::select(x, .data$Date, .data$Variable, .data$Value, .data$UpperLimit, .data$DetectionLimit, .data$Units)
+    x <- dplyr::select(x, "Date", "Variable", "Value", "UpperLimit", "DetectionLimit", "Units")
   } else {
-    x <- dplyr::select(x, .data$Date, .data$Variable, .data$Value, .data$UpperLimit, .data$Units)
+    x <- dplyr::select(x, "Date", "Variable", "Value", "UpperLimit", "Units")
   }
   x
 }

--- a/R/calc-limits.R
+++ b/R/calc-limits.R
@@ -292,10 +292,10 @@ calc_limits <- function(x, by = NULL, term = "long", dates = NULL, keep_limits =
                         messages = getOption("wqbc.messages", default = TRUE),
                         use = "Freshwater Life") {
   chk_data(x)
-  chkor(chk_null(by), check_values(by, ""))
+  chk_null_or(by, vld = vld_character)
   chk_string(term)
   chk_subset(term, c("long", "short", "long-daily"))
-  chkor(chk_null(dates), check_values(dates, Sys.Date()))
+  chk_null_or(dates, vld = vld_date)
   chk_flag(keep_limits)
   chk_flag(delete_outliers)
   chk_flag(estimate_variables)

--- a/R/clean-wqdata.R
+++ b/R/clean-wqdata.R
@@ -109,7 +109,7 @@ clean_wqdata <- function(x, by = NULL, max_cv = Inf,
                          FUN = mean) {
 
   chk_data(x)
-  chkor(chk_null(by), check_values(by, ""))
+  chk_null_or(by, vld = vld_character)
   chk_number(max_cv)
   check_values(messages, TRUE)
 

--- a/R/codes.R
+++ b/R/codes.R
@@ -33,7 +33,8 @@ wqbc_codes <- function(compress = FALSE) {
 #' @seealso \code{\link{expand_ems_codes}}
 #' @export
 compress_ems_codes <- function(x) {
-  chkor(chk_character(x), chk_s3_class(x, "factor"))
+
+  chkor_vld(vld_character(x), vld_s3_class(x, "factor"))
 
   x <- as.character(x)
   x <- gsub("[_]", "-", x)
@@ -52,7 +53,8 @@ compress_ems_codes <- function(x) {
 #' @seealso \code{\link{compress_ems_codes}}
 #' @export
 expand_ems_codes <- function(x) {
-  chkor(chk_character(x), chk_s3_class(x, "factor"))
+
+  chkor_vld(vld_character(x), vld_s3_class(x, "factor"))
 
   x <- as.character(x)
   x <- gsub("[-]", "_", x)

--- a/R/estimate-variable-values.R
+++ b/R/estimate-variable-values.R
@@ -74,7 +74,7 @@ estimate_variable_values_by <- function(x, messages) {
 estimate_variable_values <- function(data, by = NULL, variables = estimated_variables(),
                                      messages = getOption("wqbc.messages", default = TRUE)) {
   check_data(data, values = list(Date = Sys.Date(), Variable = "", Value = c(1, NA), Units = ""))
-  chkor(chk_null(by), check_values(by, ""))
+  chk_null_or(by, vld = vld_character)
   check_values(variables, "")
   if (!all(variables %in% estimated_variables())) error("Unrecognized variables")
   chk_flag(messages)

--- a/R/estimate-variable-values.R
+++ b/R/estimate-variable-values.R
@@ -66,7 +66,7 @@ estimate_variable_values_by <- function(x, messages) {
     }
 
     # remove working columns
-    x %<>% dplyr::select(-.data$yday, -.data$day)
+    x %<>% dplyr::select(-"yday", -"day")
   }
   x
 }

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -92,7 +92,7 @@ lookup_variables <- function(
     return(wqbc_codes()$Variable)
   }
 
-  chkor(chk_character(codes), chk_s3_class(codes, "factor"))
+  chkor_vld(vld_character(codes), vld_s3_class(codes, "factor"))
   codes <- as.character(codes)
   codes <- compress_ems_codes(codes)
   d <- dplyr::left_join(data.frame(Code = codes, stringsAsFactors = FALSE),
@@ -169,10 +169,10 @@ add_missing_limits <- function(x, term) {
 lookup_limits <- function(ph = NULL, hardness = NULL, chloride = NULL,
                           methyl_mercury =  NULL, term = "long",
                           use = "Freshwater Life") {
-  chkor(chk_null(ph), check_values(ph, 1))
-  chkor(chk_null(hardness), check_values(hardness, 1))
-  chkor(chk_null(chloride), check_values(chloride, 1))
-  chkor(chk_null(methyl_mercury), check_values(methyl_mercury, 1))
+  chk_null_or(ph, vld = vld_double)
+  chk_null_or(hardness, vld = vld_double)
+  chk_null_or(chloride, vld = vld_double)
+  chk_null_or(methyl_mercury, vld = vld_double)
   chk_string(term)
 
   term <- tolower(term)

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -124,11 +124,11 @@ setup_codes <- function() {
   codes <- wqbc_codes()
   codes$Date <- as.Date("2000-01-01")
   codes$Value <- 1
-  dplyr::select(codes, .data$Date, .data$Variable, .data$Value, .data$Units)
+  dplyr::select(codes, "Date", "Variable", "Value", "Units")
 }
 
 tidyup_limits <- function(x) {
-  x <- dplyr::select(x, .data$Variable, .data$UpperLimit, .data$Units)
+  x <- dplyr::select(x, "Variable", "UpperLimit", "Units")
   x$Variable <- factor(x$Variable, levels = lookup_variables())
   x$Units <- factor(x$Units, levels = lookup_units())
   x <- dplyr::arrange(x, .data$Variable)
@@ -139,7 +139,7 @@ add_missing_limits <- function(x, term) {
   limits <- wqbc_limits()
   limits <- dplyr::filter(limits, tolower(.data$Term) == tolower(term))
   limits <- dplyr::filter(limits, !.data$Variable %in% x$Variable)
-  limits <- dplyr::select(limits, .data$Variable, .data$Units)
+  limits <- dplyr::select(limits, "Variable", "Units")
   if (!nrow(limits)) {
     return(x)
   }

--- a/R/plot.R
+++ b/R/plot.R
@@ -12,30 +12,25 @@
 
 plot_timeseries_by <- function(data, title = NULL, y0, size, messages) {
   if (!is.null(title)) chk_string(title)
-  # to deal with CMD variable note
-  Date <- rlang::sym("Date")
-  Value <- rlang::sym("Value")
-  Outlier <- rlang::sym("Outlier")
-  Detected <- rlang::sym("Detected")
 
   data %<>% dplyr::mutate(Detected = detected(.data$Value, .data$DetectionLimit))
 
   data$Detected %<>% factor(levels = c(TRUE, FALSE))
   data$Outlier %<>% factor(levels = c(TRUE, FALSE))
 
-  gp <- ggplot2::ggplot(data, ggplot2::aes(x = Date, y = Value))
+  gp <- ggplot2::ggplot(data, ggplot2::aes(x = .data$Date, y = .data$Value))
 
   if (!is.null(title)) gp <- gp + ggplot2::ggtitle(title)
 
   if (any(!is.na(data$Outlier))) {
     if (any(!is.na(data$Detected))) {
-      gp <- gp + ggplot2::geom_point(ggplot2::aes(color = Outlier, alpha = Detected), size = size)
+      gp <- gp + ggplot2::geom_point(ggplot2::aes(color = .data$Outlier, alpha = .data$Detected), size = size)
     } else {
-      gp <- gp + ggplot2::geom_point(ggplot2::aes(color = Outlier), size = size)
+      gp <- gp + ggplot2::geom_point(ggplot2::aes(color = .data$Outlier), size = size)
     }
   } else {
     if (any(!is.na(data$Detected))) {
-      gp <- gp + ggplot2::geom_point(ggplot2::aes(alpha = Detected), size = size)
+      gp <- gp + ggplot2::geom_point(ggplot2::aes(alpha = .data$Detected), size = size)
     } else {
       gp <- gp + ggplot2::geom_point(size = size)
     }

--- a/R/plot.R
+++ b/R/plot.R
@@ -12,25 +12,30 @@
 
 plot_timeseries_by <- function(data, title = NULL, y0, size, messages) {
   if (!is.null(title)) chk_string(title)
+  # to deal with CMD variable note
+  Date <- rlang::sym("Date")
+  Value <- rlang::sym("Value")
+  Outlier <- rlang::sym("Outlier")
+  Detected <- rlang::sym("Detected")
 
   data %<>% dplyr::mutate(Detected = detected(.data$Value, .data$DetectionLimit))
 
   data$Detected %<>% factor(levels = c(TRUE, FALSE))
   data$Outlier %<>% factor(levels = c(TRUE, FALSE))
 
-  gp <- ggplot2::ggplot(data, ggplot2::aes_string(x = "Date", y = "Value"))
+  gp <- ggplot2::ggplot(data, ggplot2::aes(x = Date, y = Value))
 
   if (!is.null(title)) gp <- gp + ggplot2::ggtitle(title)
 
   if (any(!is.na(data$Outlier))) {
     if (any(!is.na(data$Detected))) {
-      gp <- gp + ggplot2::geom_point(ggplot2::aes_string(color = "Outlier", alpha = "Detected"), size = size)
+      gp <- gp + ggplot2::geom_point(ggplot2::aes(color = Outlier, alpha = Detected), size = size)
     } else {
-      gp <- gp + ggplot2::geom_point(ggplot2::aes_string(color = "Outlier"), size = size)
+      gp <- gp + ggplot2::geom_point(ggplot2::aes(color = Outlier), size = size)
     }
   } else {
     if (any(!is.na(data$Detected))) {
-      gp <- gp + ggplot2::geom_point(ggplot2::aes_string(alpha = "Detected"), size = size)
+      gp <- gp + ggplot2::geom_point(ggplot2::aes(alpha = Detected), size = size)
     } else {
       gp <- gp + ggplot2::geom_point(size = size)
     }

--- a/R/plot.R
+++ b/R/plot.R
@@ -74,8 +74,7 @@ plot_timeseries_fun <- function(data, by, y0, size, messages) {
 #' plot_timeseries(ccme, by = "Variable")
 plot_timeseries <- function(data, by = NULL, y0 = TRUE, size = 1,
                             messages = getOption("wqbc.messages", default = TRUE)) {
-  chkor(chk_null(by), check_values(by, ""))
-
+  chk_null_or(by, vld = vld_character)
   chk_flag(y0)
   chk_flag(messages)
 

--- a/R/substitute.R
+++ b/R/substitute.R
@@ -96,7 +96,8 @@ wqbc_substitute <- function(org, mod = org, sub, sub_mod = sub, messages) {
 #' @export
 substitute_units <- function(
   x, messages = getOption("wqbc.messages", default = TRUE)) {
-  chkor(chk_character(x), chk_s3_class(x, "factor"))
+
+  chkor_vld(vld_character(x), vld_s3_class(x, "factor"))
   check_values(messages, TRUE)
 
   x <- as.character(x)
@@ -140,7 +141,7 @@ substitute_units <- function(
 substitute_variables <- function(
   x, strict = TRUE, messages = getOption("wqbc.messages", default = TRUE)) {
 
-  chkor(chk_character(x), chk_s3_class(x, "factor"))
+  chkor_vld(vld_character(x), vld_s3_class(x, "factor"))
   check_values(strict, TRUE)
   check_values(messages, TRUE)
 

--- a/R/summarise-wqdata.R
+++ b/R/summarise-wqdata.R
@@ -77,24 +77,40 @@ summarise_wqdata_by <- function(x, censored, na.rm, conf_level, quan_range) {
   if(any(x$Value == 0)) {
     return(summarise_zero_values(x, censored))
   }
+
   ml <- with(x, cenmle(Value, Censored, dist = "lognormal", conf.int = conf_level))
+  est <- try(mean(ml), silent = TRUE)
 
-  est <- mean(ml)
-  quantiles <- quantile(ml,  c((1-quan_range)/2, quan_range + (1-quan_range)/2))
-
-  tibble::tibble(
-    n = nrow(x),
-    ncen = sum(x$Censored),
-    min = min,
-    max = max,
-    mean = est[["mean"]],
-    median = median(ml),
-    lowerQ = quantiles[[1]],
-    upperQ = quantiles[[2]],
-    sd = sd(ml),
-    se = est[["se"]],
-    lowerCL = est[[3]],
-    upperCL = est[[4]])
+  if (!is_try_error(est)) {
+    quantiles <- quantile(ml,  c((1-quan_range)/2, quan_range + (1-quan_range)/2))
+    tibble::tibble(
+      n = nrow(x),
+      ncen = sum(x$Censored),
+      min = min,
+      max = max,
+      mean = est[["mean"]],
+      median = median(ml),
+      lowerQ = quantiles[[1]],
+      upperQ = quantiles[[2]],
+      sd = sd(ml),
+      se = est[["se"]],
+      lowerCL = est[[3]],
+      upperCL = est[[4]])
+  } else {
+    tibble::tibble(
+      n = nrow(x),
+      ncen = sum(x$Censored),
+      min = min,
+      max = max,
+      mean = NA_real_,
+      median = NA_real_,
+      lowerQ = NA_real_,
+      upperQ = NA_real_,
+      sd = NA_real_,
+      se = NA_real_,
+      lowerCL = NA_real_,
+      upperCL = NA_real_)
+  }
 }
 
 summarise_wqdata_norows <- function(x, by) {

--- a/R/summarise-wqdata.R
+++ b/R/summarise-wqdata.R
@@ -63,7 +63,6 @@ summarise_wqdata_by <- function(x, censored, na.rm, conf_level, quan_range) {
   if(any(is.na(x$Value))) {
     return(summarise_missing_values(x, censored))
   }
-
   # get min and max before censored values altered
   min <- min(x$Value)
   max <- max(x$Value)
@@ -77,7 +76,6 @@ summarise_wqdata_by <- function(x, censored, na.rm, conf_level, quan_range) {
   if(any(x$Value == 0)) {
     return(summarise_zero_values(x, censored))
   }
-
   ml <- with(x, cenmle(Value, Censored, dist = "lognormal", conf.int = conf_level))
   est <- try(mean(ml), silent = TRUE)
 

--- a/R/test-trends.R
+++ b/R/test-trends.R
@@ -91,10 +91,10 @@ test_trends <- function(data, breaks = NULL, FUN = "median", messages = getOptio
     Value = c(1, NA)))
 
   # keep only relevant columns
-  data %<>% dplyr::select(.data$Station, .data$Date, .data$Variable, .data$Value, .data$Units)
+  data %<>% dplyr::select("Station", "Date", "Variable", "Value", "Units")
 
   # nest for analysis
-  data %<>% tidyr::nest(Data = c(.data$Date, .data$Value))
+  data %<>% tidyr::nest(Data = c("Date", "Value"))
 
   # fit trends
   data %<>% dplyr::mutate(Trend = purrr::map(.data$Data, do_test_trends,
@@ -102,8 +102,8 @@ test_trends <- function(data, breaks = NULL, FUN = "median", messages = getOptio
   ))
 
   # unnest and return
-  data %<>% tidyr::unnest(.data$Trend)
-  data %<>% dplyr::select(-.data$Data)
+  data %<>% tidyr::unnest("Trend")
+  data %<>% dplyr::select(-"Data")
   tibble::as_tibble(data)
 }
 
@@ -173,10 +173,10 @@ summarise_for_trends <- function(data, breaks = NULL, FUN = "median",
     Value = c(1, NA)))
 
   # keep only relevant columns
-  data %<>% dplyr::select(.data$Station, .data$Date, .data$Variable, .data$Value, .data$Units)
+  data %<>% dplyr::select("Station", "Date", "Variable", "Value", "Units")
 
   # nest for analysis
-  data %<>% tidyr::nest(Data = c(.data$Date, .data$Value))
+  data %<>% tidyr::nest(Data = c("Date", "Value"))
 
   # summarise
   data %<>% dplyr::mutate(Summary = purrr::map(.data$Data, do_summarise_for_trends,
@@ -184,8 +184,8 @@ summarise_for_trends <- function(data, breaks = NULL, FUN = "median",
   ))
 
   # unnest
-  data %<>% tidyr::unnest(.data$Summary)
-  data %<>% dplyr::select(-.data$Data)
+  data %<>% tidyr::unnest("Summary")
+  data %<>% dplyr::select(-"Data")
 
   # gather and return
   gather_cols <- setdiff(names(data), c("Station", "Variable", "Units", "Year"))

--- a/R/test-trends.R
+++ b/R/test-trends.R
@@ -189,5 +189,5 @@ summarise_for_trends <- function(data, breaks = NULL, FUN = "median",
 
   # gather and return
   gather_cols <- setdiff(names(data), c("Station", "Variable", "Units", "Year"))
-  data %>% tidyr::pivot_longer(gather_cols, names_to = "Month", values_to = "Value")
+  data %>% tidyr::pivot_longer(tidyr::all_of(gather_cols), names_to = "Month", values_to = "Value")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,3 +129,5 @@ is_color <- function(x) {
   }
   vapply(x, fun, TRUE)
 }
+
+is_try_error <- function(x) inherits(x, "try-error")

--- a/man/wqbc-package.Rd
+++ b/man/wqbc-package.Rd
@@ -6,8 +6,7 @@
 \alias{wqbc-package}
 \title{wqbc: Tidy Water Quality Data and Calculate Thresholds for British Columbia}
 \description{
-Tidies water quality data and calculates water quality thresholds 
-    for British Columbia.
+Tidies water quality data and calculates water quality thresholds for British Columbia.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-summarise-wqdata.R
+++ b/tests/testthat/test-summarise-wqdata.R
@@ -100,8 +100,26 @@ test_that("some missing values uncensored", {
 })
 
 test_that("na.rm = TRUE with only 1 non-missing value", {
-  x <- summarise_wqdata(data.frame(Variable = "1", Value = c(NA_real_, 1), stringsAsFactors = FALSE),
-                        na.rm = TRUE)
+  x <- suppressWarnings(
+    summarise_wqdata(
+      data.frame(
+        Variable = "1",
+        Value = c(NA_real_, 1),
+        stringsAsFactors = FALSE
+      ),
+      na.rm = TRUE
+    )
+  )
+  expect_warning(
+    summarise_wqdata(
+      data.frame(
+        Variable = "1",
+        Value = c(NA_real_, 1),
+        stringsAsFactors = FALSE
+      ),
+      na.rm = TRUE
+    )
+  )
   y <- tibble::tibble(Variable = "1", n = 1L, ncen = 0L, min = 1, max = 1,
     mean = NA_real_, median = NA_real_, lowerQ = NA_real_, upperQ = NA_real_,
     sd = NA_real_, se = NA_real_, lowerCL = NA_real_, upperCL = NA_real_)
@@ -109,13 +127,28 @@ test_that("na.rm = TRUE with only 1 non-missing value", {
 })
 
 test_that("multiple variables each with 1 value", {
-  x <- summarise_wqdata(data.frame(Variable = c("1", "three"), Value = c(1, 3), stringsAsFactors = FALSE))
-  y <- tibble::tibble(Variable = c("1", "three"), n = c(1L, 1L), ncen = c(0L,
-0L), min = c(1, 3), max = c(1, 3), mean = c(NA_real_, NA_real_
-), median = c(NA_real_, NA_real_), lowerQ = c(NA_real_, NA_real_
-), upperQ = c(NA_real_, NA_real_), sd = c(NA_real_, NA_real_),
-    se = c(NA_real_, NA_real_), lowerCL = c(NA_real_, NA_real_
-    ), upperCL = c(NA_real_, NA_real_))
+  expect_warning(
+    summarise_wqdata(
+      data.frame(
+        Variable = c("1", "three"), Value = c(1, 3), stringsAsFactors = FALSE
+      )
+    )
+  )
+
+  x <- suppressWarnings(
+    summarise_wqdata(
+      data.frame(
+        Variable = c("1", "three"), Value = c(1, 3), stringsAsFactors = FALSE
+      )
+    )
+  )
+
+  y <- tibble::tibble(
+    Variable = c("1", "three"), n = c(1L, 1L), ncen = c(0L, 0L), min = c(1, 3),
+    max = c(1, 3), mean = c(NA_real_, NA_real_), median = c(NA_real_, NA_real_),
+    lowerQ = c(NA_real_, NA_real_), upperQ = c(NA_real_, NA_real_),
+    sd = c(NA_real_, NA_real_), se = c(NA_real_, NA_real_),
+    lowerCL = c(NA_real_, NA_real_), upperCL = c(NA_real_, NA_real_))
 
   expect_equal(as.data.frame(x), as.data.frame(y))
 })

--- a/tests/testthat/test-tidy-data.R
+++ b/tests/testthat/test-tidy-data.R
@@ -249,10 +249,11 @@ test_that("tidy_ec_data works", {
     "SITE_NO", "DateTime", "Variable", "Code",
     "Value", "Units", "DetectionLimit", "ResultLetter"
   )
-  tidied_ec <- tidy_ec_data(test_ec)
+  expect_warning(tidy_ec_data(test_ec))
+  tidied_ec <- suppressWarnings(tidy_ec_data(test_ec))
   expect_is(tidied_ec, "ec_tidy")
   expect_equal(names(tidied_ec), default_ec_names)
-  tidied_ec <- tidy_ec_data(test_ec, cols = "STATUS_STATUT")
+  tidied_ec <- suppressWarnings(tidy_ec_data(test_ec, cols = "STATUS_STATUT"))
   expect_equal(names(tidied_ec), c(default_ec_names, "STATUS_STATUT"))
 })
 


### PR DESCRIPTION
- fixed warning and error messages in tests and R CMD Check first for various functions across the package
- to fix the summarize error in `summarise_wqdata()` a try condition was added to catch when there is not enough data to use the `cenmle()` function and it errors. Since the output of the `cenmle` function is not an error but a cenmle classed objected, the try condition has been placed on the next function which throws a regular error when the `cenmle` object doesn't have the enough data to generate the `mean` of the object. 
- when it errors it sets most of the summary values to `NA` except *n*, *ncen*, *min* and *max* which it provides from the data. This is helpful to retain as it can show the user that all the values were censored out or only a single data point remains for that site.
- the `shinyrems` app was tested and now the summary tab can be generated for many different combinations of sites and chemicals and not error out and require restarting the app